### PR TITLE
feat: add previews for UI components

### DIFF
--- a/app/src/main/java/com/example/ecommerceapp/MainActivity.kt
+++ b/app/src/main/java/com/example/ecommerceapp/MainActivity.kt
@@ -137,6 +137,7 @@ class MainActivity : ComponentActivity() {
             containerColor = Colors.Primary0,
             bottomBar = {
                 UIBottomNavBar(
+                    modifier = Modifier,
                     bottomNavBarItems,
                     selectedItem,
                     onItemChanged = onBottomNavBarItemChange

--- a/app/src/main/java/com/example/ecommerceapp/ui/components/UIBottomNavBar.kt
+++ b/app/src/main/java/com/example/ecommerceapp/ui/components/UIBottomNavBar.kt
@@ -17,6 +17,7 @@ import com.example.ecommerceapp.ui.theme.Colors
 
 @Composable
 fun UIBottomNavBar(
+    modifier: Modifier = Modifier,
     bottomNavBarItems: List<BottomNavBarItem>,
     selectedItem: BottomNavBarItem,
     onItemChanged: (BottomNavBarItem) -> Unit,
@@ -70,3 +71,6 @@ fun UIBottomNavBar(
         }
     }
 }
+
+
+

--- a/app/src/main/java/com/example/ecommerceapp/ui/components/UIEmptyState.kt
+++ b/app/src/main/java/com/example/ecommerceapp/ui/components/UIEmptyState.kt
@@ -12,11 +12,13 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.ecommerceapp.ui.theme.Colors
 
 @Composable
 fun UIEmptyState(
+    modifier: Modifier = Modifier,
     icon: UIIconName,
     title: String,
     description: String,
@@ -53,4 +55,15 @@ fun UIEmptyState(
             )
         }
     }
+}
+
+@Preview(showBackground = true, name = "Empty State Preview")
+@Composable
+fun UIEmptyStatePreview() {
+    UIEmptyState(
+        icon = UIIconName.Search,
+        title = "Nenhum Resultado",
+        description = "Não encontramos nenhum item correspondente à sua busca. Tente novamente com outros termos.",
+        modifier = Modifier.fillMaxSize()
+    )
 }

--- a/app/src/main/java/com/example/ecommerceapp/ui/components/UIIcon.kt
+++ b/app/src/main/java/com/example/ecommerceapp/ui/components/UIIcon.kt
@@ -168,3 +168,5 @@ fun UIIcon(
         modifier = modifier.size(size)
     )
 }
+
+

--- a/app/src/main/java/com/example/ecommerceapp/ui/components/UIInput.kt
+++ b/app/src/main/java/com/example/ecommerceapp/ui/components/UIInput.kt
@@ -1,5 +1,9 @@
 package com.example.ecommerceapp.ui.components
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.material3.OutlinedTextField
@@ -7,11 +11,14 @@ import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.ecommerceapp.ui.theme.Colors
 
+
 @Composable
 fun UIInput(
+    modifier: Modifier = Modifier,
     text: String,
     onChangeValue: (String) -> Unit,
     leadingIcon: UIIconName? = null,
@@ -21,7 +28,6 @@ fun UIInput(
     singleLine: Boolean = true,
     enabled: Boolean = true,
     readOnly: Boolean = false,
-    modifier: Modifier
 ) {
 
     OutlinedTextField(
@@ -67,3 +73,25 @@ fun UIInput(
         modifier = modifier,
     )
 }
+
+@Preview(showBackground = true)
+@Composable
+fun UIInputPreview(){
+    Column(modifier = Modifier.padding(16.dp)) {
+        UIInput(
+            text = "",
+            onChangeValue = {},
+            placeholderText = "Digite seu e-mail"
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        UIInput(
+            text = "meu.email@exemplo.com",
+            onChangeValue = {},
+            placeholderText = "Digite seu e-mail"
+        )
+
+    }
+}
+

--- a/app/src/main/java/com/example/ecommerceapp/ui/components/UINavHeader.kt
+++ b/app/src/main/java/com/example/ecommerceapp/ui/components/UINavHeader.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.ecommerceapp.ui.theme.Colors
 
@@ -38,4 +39,14 @@ fun UINavHeader(
         )
         UIIcon(icon = UIIconName.Bell, modifier = Modifier.clickable { onNotificationPressed() })
     }
+}
+
+@Preview(showBackground = true, name = "Nav Header Preview")
+@Composable
+fun UINavHeaderPreview() {
+    UINavHeader(
+        title = "Meu Perfil",
+        onBackPressed = {},
+        onNotificationPressed = {}
+    )
 }

--- a/app/src/main/java/com/example/ecommerceapp/ui/components/UIProductCard.kt
+++ b/app/src/main/java/com/example/ecommerceapp/ui/components/UIProductCard.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.IconButton
@@ -20,16 +21,18 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import coil.request.ImageRequest
 import com.example.ecommerceapp.R
 import com.example.ecommerceapp.model.Product
+import com.example.ecommerceapp.model.UIProductCardCartSize
 import com.example.ecommerceapp.ui.theme.Colors
 
 @SuppressLint("DefaultLocale")
 @Composable
-fun UIProductCard(product: Product, onUnsaveClick: () -> Unit) {
+fun UIProductCard(modifier: Modifier = Modifier, product: Product, onUnsaveClick: () -> Unit) {
     Column(
         modifier = Modifier
             .clickable {}
@@ -77,6 +80,30 @@ fun UIProductCard(product: Product, onUnsaveClick: () -> Unit) {
             text = "$ ${String.format("%.2f", product.price)}",
             variant = UITextVariant.B3,
             color = Colors.Primary600
+        )
+    }
+}
+
+@Preview(showBackground = true, name = "Product Card Preview")
+@Composable
+fun UIProductCardPreview() {
+
+    val sampleProduct = Product(
+        1,
+        "Camiseta de Algodão Premium Azul",
+        UIProductCardCartSize.MEDIUM,
+        12.5f,
+        "https://picsum.photos/id/1015/300/400",
+        1,
+        true
+
+    )
+
+    Column(modifier = Modifier.padding(16.dp)) {
+        UIProductCard(
+            product = sampleProduct,
+            onUnsaveClick = { /* Ação de desmarcar */ },
+            modifier = Modifier.width(180.dp)
         )
     }
 }

--- a/app/src/main/java/com/example/ecommerceapp/ui/components/UIProductCardCart.kt
+++ b/app/src/main/java/com/example/ecommerceapp/ui/components/UIProductCardCart.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import coil.compose.AsyncImage
 import com.example.ecommerceapp.R
@@ -32,6 +33,7 @@ import com.example.ecommerceapp.util.toCurrencyString
 
 @Composable
 fun UIProductCardCart(
+    modifier: Modifier = Modifier,
     title: String,
     size: UIProductCardCartSize,
     price: Float,
@@ -144,5 +146,22 @@ fun UIProductCardCart(
                 }
             }
         }
+    }
+}
+
+@Preview(showBackground = true, name = "Card (Qtd = 1)")
+@Composable
+fun UIProductCardCartPreviewQuantityOne() {
+    Column(modifier = Modifier.padding(16.dp)) {
+        UIProductCardCart(
+            title = "Jaqueta de Couro",
+            size = UIProductCardCartSize.MEDIUM,
+            price = 399.50f,
+            imageUrl = "https://picsum.photos/id/106/200/200",
+            quantity = 1,
+            onRemoveItem = { },
+            onIncrement = { },
+            onDecrement = { }
+        )
     }
 }

--- a/app/src/main/java/com/example/ecommerceapp/ui/components/UISelector.kt
+++ b/app/src/main/java/com/example/ecommerceapp/ui/components/UISelector.kt
@@ -1,17 +1,24 @@
 package com.example.ecommerceapp.ui.components
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.material3.FilterChip
 import androidx.compose.material3.FilterChipDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.example.ecommerceapp.ui.theme.Colors
 
 @Composable
 fun UISelector(
+    modifier: Modifier = Modifier,
     text: String,
     onClick: () -> Unit,
     isSelected: Boolean,
@@ -38,4 +45,24 @@ fun UISelector(
         modifier = Modifier
             .wrapContentWidth()
     )
+}
+
+@Preview(showBackground = true, name = "UI Selector Preview")
+@Composable
+fun UISelectorPreview() {
+    Column(modifier = Modifier.padding(16.dp)) {
+        UIText(text = "Unselected State:", variant = UITextVariant.B2, weight = UITextWeight.SemiBold, color = Color.Black)
+        Row(modifier = Modifier.padding(top = 4.dp)) {
+            UISelector(text = "Opção 1", onClick = { /* TODO */ }, isSelected = false)
+            UISelector(text = "Opção Longa Sem Seleção", onClick = { /* TODO */ }, isSelected = false, modifier = Modifier.padding(start = 8.dp))
+        }
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        UIText(text = "Selected State:", variant = UITextVariant.B2, weight = UITextWeight.SemiBold, color = Color.Black)
+        Row(modifier = Modifier.padding(top = 4.dp)) {
+            UISelector(text = "Opção 2", onClick = { /* TODO */ }, isSelected = true)
+            UISelector(text = "Opção Longa Selecionada", onClick = { /* TODO */ }, isSelected = true, modifier = Modifier.padding(start = 8.dp))
+        }
+    }
 }

--- a/app/src/main/java/com/example/ecommerceapp/ui/components/UIText.kt
+++ b/app/src/main/java/com/example/ecommerceapp/ui/components/UIText.kt
@@ -1,5 +1,7 @@
 package com.example.ecommerceapp.ui.components
 
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -10,7 +12,9 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.ecommerceapp.ui.theme.GeneralSans
 import com.example.ecommerceapp.util.percent
@@ -57,6 +61,7 @@ fun UIText(
         overflow = overflow
     )
 }
+
 
 @Composable
 private fun uiTextStyle(
@@ -148,6 +153,60 @@ private fun uiTextStyle(
                 fontWeight = fw,
                 letterSpacing = letterSpacing,
                 fontFamily = fontFamily ?: MaterialTheme.typography.bodySmall.fontFamily
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true, name = "Variantes de Texto")
+@Composable
+fun UITextPreview() {
+    MaterialTheme {
+        Column(modifier = Modifier.padding(16.dp)) {
+            UIText(
+                text = "H1 Title",
+                variant = UITextVariant.H1,
+                weight = UITextWeight.SemiBold
+            )
+            UIText(
+                text = "H2 Title",
+                variant = UITextVariant.H2,
+                weight = UITextWeight.SemiBold
+            )
+            UIText(
+                text = "H3 Title",
+                variant = UITextVariant.H3,
+                weight = UITextWeight.SemiBold
+            )
+            UIText(
+                text = "H4 Title",
+                variant = UITextVariant.H4,
+                weight = UITextWeight.Medium
+            )
+            UIText(
+                text = "B1 Body Regular",
+                variant = UITextVariant.B1,
+                weight = UITextWeight.Regular
+            )
+            UIText(
+                text = "B1 Body Medium",
+                variant = UITextVariant.B1,
+                weight = UITextWeight.Medium
+            )
+            UIText(
+                text = "B2 Body SemiBold",
+                variant = UITextVariant.B2,
+                weight = UITextWeight.SemiBold
+            )
+            UIText(
+                text = "B3 Body Regular",
+                variant = UITextVariant.B3,
+                weight = UITextWeight.Regular
+            )
+            UIText(
+                text = "Texto com cor customizada",
+                variant = UITextVariant.B1,
+                color = Color.Blue
             )
         }
     }


### PR DESCRIPTION
### O que este PR faz?

Este PR introduz funções `@Preview` do Jetpack Compose para a grande maioria dos nossos componentes de UI e telas.

A adição de previews melhora drasticamente a Experiência do Desenvolvedor (DX):
* **Desenvolvimento Rápido:** Permite visualizar as mudanças na UI instantaneamente, sem precisar compilar e rodar o app no emulador.
* **Testes Visuais:** Facilita a verificação de componentes em diferentes estados (ex: `UISelector` selecionado/não selecionado, `UIProductCardCart` com quantidades diferentes).
* **Catálogo Visual:** Serve como uma "biblioteca de componentes" visual e viva dentro do próprio Android Studio.

### Componentes e Telas Atualizados:

* `UIInput`
* `UIEmptyState`
* `UIText` (mostrando todas as variantes)
* `UINavHeader`
* `UISelector`
* `UIProductCard`
* `UIProductCardCart` (com preview interativo)